### PR TITLE
日本語ページがリンクされない問題を修正

### DIFF
--- a/lib/Blacket.js
+++ b/lib/Blacket.js
@@ -25,7 +25,7 @@ class Blacket {
     if (this.isExternalLink()) {
       return this.toMarkdownExternalLink();
     }
-    return link(keyword, `./${keyword}.md`);
+    return link(keyword, `./${encodeURIComponent(keyword)}.md`);
   }
   keyword() {
     return this.chars.slice(1, -1).join('');

--- a/lib/Hashtag.js
+++ b/lib/Hashtag.js
@@ -13,7 +13,7 @@ class Hashtag {
     this.chars.push(chars.shift());
   }
   toMarkdown() {
-    return link(`#${this.keyword()}`, `./${this.keyword()}.md`);
+    return link(`#${this.keyword()}`, `./${encodeURIComponent(this.keyword())}.md`);
   }
   keyword() {
     return this.chars.slice(1).join('');

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -8,3 +8,7 @@ test('indent', t => {
 test('link', t => {
   t.is(sb2md('[日本語]'), '[日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
 });
+
+test('hashtag', t => {
+  t.is(sb2md('#日本語'), '[#日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
+});

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -1,6 +1,10 @@
 import test from 'ava';
-import { sb2md } from 'lib/sb2md';
+const { sb2md } = require('../lib/sb2md');
 
 test('indent', t => {
     t.is(sb2md(' a'), '  - a');
+});
+
+test('link', t => {
+  t.is(sb2md('[日本語]'), '[日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
 });


### PR DESCRIPTION
[showdown](https://github.com/showdownjs/showdown)が `[hoge](./日本語.md)` のような日本語ページへのリンクを `a` タグに変換してくれないので、 `日本語` 部分を `encodeURIComponent` するように修正しました。