### PR TITLE
[*** 大きな強調文字] への対応と正規表現バグ修正など

### DIFF
--- a/lib/Bracket.js
+++ b/lib/Bracket.js
@@ -43,18 +43,7 @@ class Bracket {
     }
     if (!/^[*_-]+/.test(chars.join(''))) {
       // `[link text]`
-      this.link = true;
-      while (chars.length > 0 && chars[0] !== ']') {
-        const c = chars.shift();
-        this.chars.push(c);
-        this.symbols.push(c);
-      }
-      if (chars.length <= 0) {
-        this.link = false;
-        this.symbols.splice(0, this.symbols.length);
-        return;
-      }
-      this.chars.push(chars.shift());
+      this.parseLink(chars);
       return;
     }
 
@@ -81,7 +70,15 @@ class Bracket {
     }
 
     // remove spaces
-    const numSpaces = chars.join('').match(/^\s+/)[0].length;
+    const spaces = chars.join('').match(/^\s+/);
+    if (!spaces) {
+      // no space after control chars: treat this as a link
+      this.bold = this.del = this.u = 0;
+      this.symbols.push(...this.chars.slice(1), c);
+      this.parseLink(chars);
+      return;
+    }
+    const numSpaces = spaces[0].length;
     this.chars.push(c, ...chars.splice(0, numSpaces));
 
     // parse bracket content
@@ -95,6 +92,20 @@ class Bracket {
     }
     this.symbols.push(...res.symbols);
     this.chars.push(...chars.splice(0, chars.length - res.left + 1));
+  }
+  parseLink(chars) {
+    this.link = true;
+    while (chars.length > 0 && chars[0] !== ']') {
+      const c = chars.shift();
+      this.chars.push(c);
+      this.symbols.push(c);
+    }
+    if (chars.length <= 0) {
+      this.link = false;
+      this.symbols.splice(0, this.symbols.length);
+      return;
+    }
+    this.chars.push(chars.shift());
   }
   toMarkdown() {
     if (this.symbols.length > 0) {

--- a/lib/Bracket.js
+++ b/lib/Bracket.js
@@ -21,7 +21,7 @@ class Bracket {
     }
     if (chars[0] === '[') {
       // `[[bold text]]`
-      this.bold = true;
+      this.bold = 1;
       this.chars.push(chars.shift());
 
       // parse bracket content
@@ -29,7 +29,7 @@ class Bracket {
       if (!res) {
         // closing `]` not found
         this.chars.push(...chars.splice(0, chars.length));
-        this.bold = false;
+        this.bold = 0;
         this.symbols.splice(0, this.symbols.length);
         return;
       }
@@ -60,22 +60,24 @@ class Bracket {
 
     // check control char
     const c = chars.shift();
+    let level = 1;
+    while (chars[0] === c) {
+      this.chars.push(chars.shift());
+      level ++;
+    }
     switch (c) {
       case '*':
         // `[* bold text]`
-        this.bold = true;
+        this.bold = level;
         break;
       case '-':
         // `[- strike text]`
-        this.del = true;
+        this.del = level;
         break;
       case '_':
         // `[_ underline text]`
-        this.u = true;
+        this.u = level;
         break;
-    }
-    while (chars[0] === c) {
-      this.chars.push(chars.shift());
     }
 
     // remove spaces
@@ -87,7 +89,7 @@ class Bracket {
     if (!res) {
       // closing `]` not found
       this.chars.push(...chars.splice(0, chars.length));
-      this.bold = this.del = this.u = false;
+      this.bold = this.del = this.u = 0;
       this.symbols.splice(0, this.symbols.length);
       return;
     }
@@ -102,7 +104,7 @@ class Bracket {
         // return `[${text}](./${encodeURIComponent(text)}.md)`;
       }
       if (this.bold) {
-        return `<b>${s2md(this.symbols)}</b>`;
+        return `<b${this.bold <= 1 ? "" : ` style="font-size:${(0.8 + this.bold * 0.2).toFixed(1)}em;" class="level-${this.bold}"`}>${s2md(this.symbols)}</b>`;
       }
       if (this.del) {
         return `<del>${s2md(this.symbols)}</del>`;

--- a/lib/Bracket.js
+++ b/lib/Bracket.js
@@ -41,7 +41,7 @@ class Bracket {
       this.chars.push(chars.shift());
       return;
     }
-    if (!/^[*-_]+/.test(chars.join(''))) {
+    if (!/^[*_-]+/.test(chars.join(''))) {
       // `[link text]`
       this.link = true;
       while (chars.length > 0 && chars[0] !== ']') {

--- a/lib/Bracket.js
+++ b/lib/Bracket.js
@@ -41,9 +41,7 @@ class Bracket {
       this.chars.push(chars.shift());
       return;
     }
-    if (!/^[*-_]$/.test(chars[0])
-        || chars.length <= 1
-        || !/^\s$/.test(chars[1])) {
+    if (!/^[*-_]+/.test(chars.join(''))) {
       // `[link text]`
       this.link = true;
       while (chars.length > 0 && chars[0] !== ']') {
@@ -75,6 +73,9 @@ class Bracket {
         // `[_ underline text]`
         this.u = true;
         break;
+    }
+    while (chars[0] === c) {
+      this.chars.push(chars.shift());
     }
 
     // remove spaces

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -5,12 +5,16 @@ test('indent', t => {
     t.is(sb2md(' a'), '  - a');
 });
 
-test('single', t => {
+test('single em', t => {
   t.is(sb2md("[* 強調]"), '<b>強調</b>');
 });
 
-test('triple', t => {
+test('triple em', t => {
   t.is(sb2md("[*** 強調]"), '<b style="font-size:1.4em;" class="level-3">強調</b>');
+});
+
+test('not em but link', t => {
+  t.is(sb2md('[*test]'), "[*test](./*test.md)");
 });
 
 test('link', t => {

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -5,6 +5,10 @@ test('indent', t => {
     t.is(sb2md(' a'), '  - a');
 });
 
+test('triple', t => {
+  t.is(sb2md("[*** 強調]"), '<b>強調</b>');
+});
+
 test('link', t => {
   t.is(sb2md('[日本語]'), '[日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
 });

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -5,8 +5,12 @@ test('indent', t => {
     t.is(sb2md(' a'), '  - a');
 });
 
+test('single', t => {
+  t.is(sb2md("[* 強調]"), '<b>強調</b>');
+});
+
 test('triple', t => {
-  t.is(sb2md("[*** 強調]"), '<b>強調</b>');
+  t.is(sb2md("[*** 強調]"), '<b style="font-size:1.4em;" class="level-3">強調</b>');
 });
 
 test('link', t => {

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -17,6 +17,10 @@ test('link', t => {
   t.is(sb2md('[日本語]'), '[日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
 });
 
+test('numerical link', t => {
+  t.is(sb2md('[0]'), "[0](./0.md)");
+});
+
 test('hashtag', t => {
   t.is(sb2md('#日本語'), '[#日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
 });


### PR DESCRIPTION
何度もすみません。バグ修正が入っているのでなるべく（そこ ac0234c だけcherrypickしてでも）マージしていただけると嬉しいです。

- `[* a]` `[** b]` `[*** c]` のようにコントロール文字を重ねて強調度合いを上げる書式に対応しました
- コントロール文字のマッチを `[*-_]` で取っていたために `*`, `-`, `_` のいずれか **ではなく** 文字コード `*` から `_` までの範囲が誤ってマッチしてしまっていた問題を修正しました
- `[*abc]` のようにコントロール文字で始まるがスペースが挟まらないブラケットを、単なるリンクとして扱うようにしました