### PR TITLE
Scrapbox内部リンクへの対応

### DIFF
--- a/lib/Link.js
+++ b/lib/Link.js
@@ -17,7 +17,8 @@ class Link {
     return this.text.charAt(0) === '/';
   }
   toMarkdownRelativeLink() {
-    return link(this.text, 'https://scrapbox.io' + this.text);
+    return link(this.text, 'https://scrapbox.io'
+      + this.text.split("/").map(t => encodeURIComponent(t)).join("/"));
   }
   isExternalLink() {
     const segments = this.text.split(/ /);

--- a/test/sb2md.js
+++ b/test/sb2md.js
@@ -25,6 +25,10 @@ test('numerical link', t => {
   t.is(sb2md('[0]'), "[0](./0.md)");
 });
 
+test('internal link', t => {
+  t.is(sb2md('[/textalive/TextAlive Fonts]'), "[/textalive/TextAlive Fonts](https://scrapbox.io/textalive/TextAlive%20Fonts)");
+});
+
 test('hashtag', t => {
   t.is(sb2md('#日本語'), '[#日本語](./%E6%97%A5%E6%9C%AC%E8%AA%9E.md)');
 });


### PR DESCRIPTION
- `[/Scrapbox/Internal Link]` 形式のリンクが `[/Scrapbox/Internal Link](https://scrapbox.io/Scrapbox/Internal Link)` に変換され、Markdownのリンクとして認識されないバグがあったので修正しました。
  - 修正後は `[/Scrapbox/Internal Link](https://scrapbox.io/Scrapbox/Internal%20Link)` になります
- 該当するテストケースを一つ足しました
